### PR TITLE
Fix the passiveMobSpawning=false still spawn mobs in night.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     minecraft "net.minecraftforge:forge:${project.minecraft_version}-${project.forge_version}"
 
     // Core library
-//    implementation fg.deobf("curse.maven:supermartijn642s-core-lib-454372:${project.core_library_file}")
-    implementation fg.deobf("com.supermartijn642:supermartijn642corelib:1.1.0-forge-mc1.18")
+    implementation fg.deobf("curse.maven:supermartijn642s-core-lib-454372:${project.core_library_file}")
+    //implementation fg.deobf("com.supermartijn642:supermartijn642corelib:1.1.0-forge-mc1.18")
     // Config library
     implementation fg.deobf("curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file}")
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     // Core library
     implementation fg.deobf("curse.maven:supermartijn642s-core-lib-454372:${project.core_library_file}")
-    //implementation fg.deobf("com.supermartijn642:supermartijn642corelib:1.1.0-forge-mc1.18")
+//    implementation fg.deobf("com.supermartijn642:supermartijn642corelib:1.1.0-forge-mc1.18")
     // Config library
     implementation fg.deobf("curse.maven:supermartijn642s-config-lib-438332:${project.config_library_file}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ modrinth_required_dependency_ids=supermartijn642s-core-lib supermartijn642s-conf
 modrinth_optional_dependency_ids=
 
 # Dependencies
-core_library_file=4393114
+core_library_file=4455384
 core_library_dependency=[1.1.0,1.2.0)
 config_library_file=3862966
 config_library_dependency=[1.1.6,)

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ modrinth_required_dependency_ids=supermartijn642s-core-lib supermartijn642s-conf
 modrinth_optional_dependency_ids=
 
 # Dependencies
-core_library_file=3649270
+core_library_file=4393114
 core_library_dependency=[1.1.0,1.2.0)
 config_library_file=3862966
 config_library_dependency=[1.1.6,)

--- a/src/main/java/com/supermartijn642/scarecrowsterritory/ScarecrowTracker.java
+++ b/src/main/java/com/supermartijn642/scarecrowsterritory/ScarecrowTracker.java
@@ -46,7 +46,8 @@ public class ScarecrowTracker {
     @SubscribeEvent
     public static void onWorldTick(TickEvent.WorldTickEvent e){
         Level level = e.world;
-        if(level.isClientSide || !(level instanceof ServerLevel) || level.isDebug())
+        if(!ScarecrowsTerritoryConfig.passiveMobSpawning.get() || level.isClientSide
+                || !(level instanceof ServerLevel) || level.isDebug())
             return;
 
         if(!level.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING))


### PR DESCRIPTION
![2023-02-14_11 38 04](https://user-images.githubusercontent.com/7941967/218634094-9d2afafa-ff51-48fb-839b-04069264aab9.png)

I guess the meaning from the description _"Should mobs passively spawn within the scarecrows' range"_
Even if it is false, the mobs still spawn around the scarecrows.
(Nearly killed me in survival mode)
